### PR TITLE
Implement a proper fix for culture-specific decimal parsing in .cfg files, and a couple other miscellaneous changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# Visual Studio Code build/task scripts directory
+.vscode/
+
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 

--- a/CHColourEditor/ColorEditor.Designer.cs
+++ b/CHColourEditor/ColorEditor.Designer.cs
@@ -63,15 +63,15 @@ namespace CHColourEditor
             this.texturePreviewContainer = new System.Windows.Forms.GroupBox();
             this.texturePreviewImg = new System.Windows.Forms.PictureBox();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem5 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem6 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem7 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem8 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem9 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenu_FileTab = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenu_New = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenu_Open = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenu_Save = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenu_SaveAs = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenu_HelpTab = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenu_Changelog = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenu_CheckForUpdates = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenu_About = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.editorContainer)).BeginInit();
             this.editorContainer.Panel1.SuspendLayout();
             this.editorContainer.Panel2.SuspendLayout();
@@ -98,19 +98,16 @@ namespace CHColourEditor
             // guitarList
             // 
             this.guitarList.FormattingEnabled = true;
-            this.guitarList.ItemHeight = 25;
-            this.guitarList.Location = new System.Drawing.Point(6, 6);
-            this.guitarList.Margin = new System.Windows.Forms.Padding(6);
+            this.guitarList.Location = new System.Drawing.Point(3, 3);
             this.guitarList.Name = "guitarList";
-            this.guitarList.Size = new System.Drawing.Size(502, 604);
+            this.guitarList.Size = new System.Drawing.Size(253, 316);
             this.guitarList.TabIndex = 0;
             this.guitarList.SelectedIndexChanged += new System.EventHandler(this.guitarList_SelectedIndexChanged);
             // 
             // editorContainer
             // 
             this.editorContainer.Enabled = false;
-            this.editorContainer.Location = new System.Drawing.Point(24, 79);
-            this.editorContainer.Margin = new System.Windows.Forms.Padding(6);
+            this.editorContainer.Location = new System.Drawing.Point(12, 41);
             this.editorContainer.Name = "editorContainer";
             // 
             // editorContainer.Panel1
@@ -138,9 +135,8 @@ namespace CHColourEditor
             this.editorContainer.Panel2.Controls.Add(this.labelHex);
             this.editorContainer.Panel2.Controls.Add(this.labelCurrentColor);
             this.editorContainer.Panel2.Controls.Add(this.labelCurrent);
-            this.editorContainer.Size = new System.Drawing.Size(1402, 696);
-            this.editorContainer.SplitterDistance = 548;
-            this.editorContainer.SplitterWidth = 8;
+            this.editorContainer.Size = new System.Drawing.Size(701, 362);
+            this.editorContainer.SplitterDistance = 274;
             this.editorContainer.TabIndex = 8;
             this.editorContainer.Visible = false;
             // 
@@ -149,22 +145,20 @@ namespace CHColourEditor
             this.tabControl1.Controls.Add(this.guitarPage);
             this.tabControl1.Controls.Add(this.drumsPage);
             this.tabControl1.Controls.Add(this.otherPage);
-            this.tabControl1.Location = new System.Drawing.Point(6, 8);
-            this.tabControl1.Margin = new System.Windows.Forms.Padding(6);
+            this.tabControl1.Location = new System.Drawing.Point(3, 4);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(534, 669);
+            this.tabControl1.Size = new System.Drawing.Size(267, 348);
             this.tabControl1.TabIndex = 7;
             this.tabControl1.SelectedIndexChanged += new System.EventHandler(this.tabControl1_SelectedIndexChanged);
             // 
             // guitarPage
             // 
             this.guitarPage.Controls.Add(this.guitarList);
-            this.guitarPage.Location = new System.Drawing.Point(8, 39);
-            this.guitarPage.Margin = new System.Windows.Forms.Padding(6);
+            this.guitarPage.Location = new System.Drawing.Point(4, 22);
             this.guitarPage.Name = "guitarPage";
-            this.guitarPage.Padding = new System.Windows.Forms.Padding(6);
-            this.guitarPage.Size = new System.Drawing.Size(518, 622);
+            this.guitarPage.Padding = new System.Windows.Forms.Padding(3);
+            this.guitarPage.Size = new System.Drawing.Size(259, 322);
             this.guitarPage.TabIndex = 0;
             this.guitarPage.Text = "Guitar";
             this.guitarPage.UseVisualStyleBackColor = true;
@@ -172,11 +166,10 @@ namespace CHColourEditor
             // drumsPage
             // 
             this.drumsPage.Controls.Add(this.drumsList);
-            this.drumsPage.Location = new System.Drawing.Point(8, 39);
-            this.drumsPage.Margin = new System.Windows.Forms.Padding(6);
+            this.drumsPage.Location = new System.Drawing.Point(4, 22);
             this.drumsPage.Name = "drumsPage";
-            this.drumsPage.Padding = new System.Windows.Forms.Padding(6);
-            this.drumsPage.Size = new System.Drawing.Size(518, 622);
+            this.drumsPage.Padding = new System.Windows.Forms.Padding(3);
+            this.drumsPage.Size = new System.Drawing.Size(259, 322);
             this.drumsPage.TabIndex = 1;
             this.drumsPage.Text = "Drums";
             this.drumsPage.UseVisualStyleBackColor = true;
@@ -184,22 +177,19 @@ namespace CHColourEditor
             // drumsList
             // 
             this.drumsList.FormattingEnabled = true;
-            this.drumsList.ItemHeight = 25;
-            this.drumsList.Location = new System.Drawing.Point(6, 6);
-            this.drumsList.Margin = new System.Windows.Forms.Padding(6);
+            this.drumsList.Location = new System.Drawing.Point(3, 3);
             this.drumsList.Name = "drumsList";
-            this.drumsList.Size = new System.Drawing.Size(502, 604);
+            this.drumsList.Size = new System.Drawing.Size(253, 316);
             this.drumsList.TabIndex = 1;
             this.drumsList.SelectedIndexChanged += new System.EventHandler(this.drumsList_SelectedIndexChanged);
             // 
             // otherPage
             // 
             this.otherPage.Controls.Add(this.otherList);
-            this.otherPage.Location = new System.Drawing.Point(8, 39);
-            this.otherPage.Margin = new System.Windows.Forms.Padding(6);
+            this.otherPage.Location = new System.Drawing.Point(4, 22);
             this.otherPage.Name = "otherPage";
-            this.otherPage.Padding = new System.Windows.Forms.Padding(6);
-            this.otherPage.Size = new System.Drawing.Size(518, 622);
+            this.otherPage.Padding = new System.Windows.Forms.Padding(3);
+            this.otherPage.Size = new System.Drawing.Size(259, 322);
             this.otherPage.TabIndex = 2;
             this.otherPage.Text = "Other";
             this.otherPage.UseVisualStyleBackColor = true;
@@ -207,20 +197,17 @@ namespace CHColourEditor
             // otherList
             // 
             this.otherList.FormattingEnabled = true;
-            this.otherList.ItemHeight = 25;
-            this.otherList.Location = new System.Drawing.Point(6, 6);
-            this.otherList.Margin = new System.Windows.Forms.Padding(6);
+            this.otherList.Location = new System.Drawing.Point(3, 3);
             this.otherList.Name = "otherList";
-            this.otherList.Size = new System.Drawing.Size(502, 604);
+            this.otherList.Size = new System.Drawing.Size(253, 316);
             this.otherList.TabIndex = 1;
             this.otherList.SelectedIndexChanged += new System.EventHandler(this.otherList_SelectedIndexChanged);
             // 
             // updateColorBtn
             // 
-            this.updateColorBtn.Location = new System.Drawing.Point(314, 583);
-            this.updateColorBtn.Margin = new System.Windows.Forms.Padding(6);
+            this.updateColorBtn.Location = new System.Drawing.Point(157, 303);
             this.updateColorBtn.Name = "updateColorBtn";
-            this.updateColorBtn.Size = new System.Drawing.Size(188, 44);
+            this.updateColorBtn.Size = new System.Drawing.Size(94, 23);
             this.updateColorBtn.TabIndex = 32;
             this.updateColorBtn.Text = "Update Color";
             this.updateColorBtn.UseVisualStyleBackColor = true;
@@ -228,20 +215,18 @@ namespace CHColourEditor
             // 
             // textboxHexColor
             // 
-            this.textboxHexColor.Location = new System.Drawing.Point(166, 587);
-            this.textboxHexColor.Margin = new System.Windows.Forms.Padding(6);
+            this.textboxHexColor.Location = new System.Drawing.Point(83, 305);
             this.textboxHexColor.Name = "textboxHexColor";
-            this.textboxHexColor.Size = new System.Drawing.Size(132, 31);
+            this.textboxHexColor.Size = new System.Drawing.Size(68, 20);
             this.textboxHexColor.TabIndex = 31;
             this.textboxHexColor.Text = "FFFFFF";
             this.textboxHexColor.TextChanged += new System.EventHandler(this.textboxHexColor_TextChanged);
             // 
             // numLuminance
             // 
-            this.numLuminance.Location = new System.Drawing.Point(694, 367);
-            this.numLuminance.Margin = new System.Windows.Forms.Padding(6);
+            this.numLuminance.Location = new System.Drawing.Point(347, 191);
             this.numLuminance.Name = "numLuminance";
-            this.numLuminance.Size = new System.Drawing.Size(108, 31);
+            this.numLuminance.Size = new System.Drawing.Size(54, 20);
             this.numLuminance.TabIndex = 13;
             this.numLuminance.Value = new decimal(new int[] {
             100,
@@ -253,10 +238,9 @@ namespace CHColourEditor
             // radioLuminance
             // 
             this.radioLuminance.AutoSize = true;
-            this.radioLuminance.Location = new System.Drawing.Point(608, 367);
-            this.radioLuminance.Margin = new System.Windows.Forms.Padding(6);
+            this.radioLuminance.Location = new System.Drawing.Point(304, 191);
             this.radioLuminance.Name = "radioLuminance";
-            this.radioLuminance.Size = new System.Drawing.Size(61, 29);
+            this.radioLuminance.Size = new System.Drawing.Size(34, 17);
             this.radioLuminance.TabIndex = 12;
             this.radioLuminance.Text = "L:";
             this.radioLuminance.UseVisualStyleBackColor = true;
@@ -264,10 +248,9 @@ namespace CHColourEditor
             // 
             // numSaturation
             // 
-            this.numSaturation.Location = new System.Drawing.Point(694, 317);
-            this.numSaturation.Margin = new System.Windows.Forms.Padding(6);
+            this.numSaturation.Location = new System.Drawing.Point(347, 165);
             this.numSaturation.Name = "numSaturation";
-            this.numSaturation.Size = new System.Drawing.Size(108, 31);
+            this.numSaturation.Size = new System.Drawing.Size(54, 20);
             this.numSaturation.TabIndex = 11;
             this.numSaturation.Value = new decimal(new int[] {
             100,
@@ -279,10 +262,9 @@ namespace CHColourEditor
             // radioSaturation
             // 
             this.radioSaturation.AutoSize = true;
-            this.radioSaturation.Location = new System.Drawing.Point(608, 317);
-            this.radioSaturation.Margin = new System.Windows.Forms.Padding(6);
+            this.radioSaturation.Location = new System.Drawing.Point(304, 165);
             this.radioSaturation.Name = "radioSaturation";
-            this.radioSaturation.Size = new System.Drawing.Size(63, 29);
+            this.radioSaturation.Size = new System.Drawing.Size(35, 17);
             this.radioSaturation.TabIndex = 10;
             this.radioSaturation.Text = "S:";
             this.radioSaturation.UseVisualStyleBackColor = true;
@@ -290,15 +272,14 @@ namespace CHColourEditor
             // 
             // numHue
             // 
-            this.numHue.Location = new System.Drawing.Point(694, 267);
-            this.numHue.Margin = new System.Windows.Forms.Padding(6);
+            this.numHue.Location = new System.Drawing.Point(347, 139);
             this.numHue.Maximum = new decimal(new int[] {
             359,
             0,
             0,
             0});
             this.numHue.Name = "numHue";
-            this.numHue.Size = new System.Drawing.Size(108, 31);
+            this.numHue.Size = new System.Drawing.Size(54, 20);
             this.numHue.TabIndex = 9;
             this.numHue.ValueChanged += new System.EventHandler(this.numHue_ValueChanged);
             // 
@@ -306,10 +287,9 @@ namespace CHColourEditor
             // 
             this.radioHue.AutoSize = true;
             this.radioHue.Checked = true;
-            this.radioHue.Location = new System.Drawing.Point(608, 267);
-            this.radioHue.Margin = new System.Windows.Forms.Padding(6);
+            this.radioHue.Location = new System.Drawing.Point(304, 139);
             this.radioHue.Name = "radioHue";
-            this.radioHue.Size = new System.Drawing.Size(64, 29);
+            this.radioHue.Size = new System.Drawing.Size(36, 17);
             this.radioHue.TabIndex = 8;
             this.radioHue.TabStop = true;
             this.radioHue.Text = "H:";
@@ -318,25 +298,23 @@ namespace CHColourEditor
             // 
             // numBlue
             // 
-            this.numBlue.Location = new System.Drawing.Point(694, 183);
-            this.numBlue.Margin = new System.Windows.Forms.Padding(6);
+            this.numBlue.Location = new System.Drawing.Point(347, 95);
             this.numBlue.Maximum = new decimal(new int[] {
             255,
             0,
             0,
             0});
             this.numBlue.Name = "numBlue";
-            this.numBlue.Size = new System.Drawing.Size(108, 31);
+            this.numBlue.Size = new System.Drawing.Size(54, 20);
             this.numBlue.TabIndex = 7;
             this.numBlue.ValueChanged += new System.EventHandler(this.numBlue_ValueChanged);
             // 
             // radioBlue
             // 
             this.radioBlue.AutoSize = true;
-            this.radioBlue.Location = new System.Drawing.Point(608, 183);
-            this.radioBlue.Margin = new System.Windows.Forms.Padding(6);
+            this.radioBlue.Location = new System.Drawing.Point(304, 95);
             this.radioBlue.Name = "radioBlue";
-            this.radioBlue.Size = new System.Drawing.Size(63, 29);
+            this.radioBlue.Size = new System.Drawing.Size(35, 17);
             this.radioBlue.TabIndex = 6;
             this.radioBlue.Text = "B:";
             this.radioBlue.UseVisualStyleBackColor = true;
@@ -344,25 +322,23 @@ namespace CHColourEditor
             // 
             // numGreen
             // 
-            this.numGreen.Location = new System.Drawing.Point(694, 133);
-            this.numGreen.Margin = new System.Windows.Forms.Padding(6);
+            this.numGreen.Location = new System.Drawing.Point(347, 69);
             this.numGreen.Maximum = new decimal(new int[] {
             255,
             0,
             0,
             0});
             this.numGreen.Name = "numGreen";
-            this.numGreen.Size = new System.Drawing.Size(108, 31);
+            this.numGreen.Size = new System.Drawing.Size(54, 20);
             this.numGreen.TabIndex = 5;
             this.numGreen.ValueChanged += new System.EventHandler(this.numGreen_ValueChanged);
             // 
             // radioGreen
             // 
             this.radioGreen.AutoSize = true;
-            this.radioGreen.Location = new System.Drawing.Point(608, 133);
-            this.radioGreen.Margin = new System.Windows.Forms.Padding(6);
+            this.radioGreen.Location = new System.Drawing.Point(304, 69);
             this.radioGreen.Name = "radioGreen";
-            this.radioGreen.Size = new System.Drawing.Size(65, 29);
+            this.radioGreen.Size = new System.Drawing.Size(36, 17);
             this.radioGreen.TabIndex = 4;
             this.radioGreen.Text = "G:";
             this.radioGreen.UseVisualStyleBackColor = true;
@@ -370,15 +346,14 @@ namespace CHColourEditor
             // 
             // numRed
             // 
-            this.numRed.Location = new System.Drawing.Point(694, 83);
-            this.numRed.Margin = new System.Windows.Forms.Padding(6);
+            this.numRed.Location = new System.Drawing.Point(347, 43);
             this.numRed.Maximum = new decimal(new int[] {
             255,
             0,
             0,
             0});
             this.numRed.Name = "numRed";
-            this.numRed.Size = new System.Drawing.Size(108, 31);
+            this.numRed.Size = new System.Drawing.Size(54, 20);
             this.numRed.TabIndex = 3;
             this.numRed.Value = new decimal(new int[] {
             255,
@@ -390,10 +365,9 @@ namespace CHColourEditor
             // radioRed
             // 
             this.radioRed.AutoSize = true;
-            this.radioRed.Location = new System.Drawing.Point(608, 83);
-            this.radioRed.Margin = new System.Windows.Forms.Padding(6);
+            this.radioRed.Location = new System.Drawing.Point(304, 43);
             this.radioRed.Name = "radioRed";
-            this.radioRed.Size = new System.Drawing.Size(64, 29);
+            this.radioRed.Size = new System.Drawing.Size(36, 17);
             this.radioRed.TabIndex = 2;
             this.radioRed.Text = "R:";
             this.radioRed.UseVisualStyleBackColor = true;
@@ -402,13 +376,13 @@ namespace CHColourEditor
             // colorSlider
             // 
             this.colorSlider.ColorMode = MechanikaDesign.WinForms.UI.ColorPicker.ColorModes.Hue;
-            this.colorSlider.ColorRGB = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(255)))), ((int)(((byte)(241)))));
-            this.colorSlider.Location = new System.Drawing.Point(514, 65);
-            this.colorSlider.Margin = new System.Windows.Forms.Padding(12);
+            this.colorSlider.ColorRGB = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.colorSlider.Location = new System.Drawing.Point(257, 34);
+            this.colorSlider.Margin = new System.Windows.Forms.Padding(6);
             this.colorSlider.Name = "colorSlider";
             this.colorSlider.NubColor = System.Drawing.Color.White;
-            this.colorSlider.Position = 143;
-            this.colorSlider.Size = new System.Drawing.Size(80, 485);
+            this.colorSlider.Position = 142;
+            this.colorSlider.Size = new System.Drawing.Size(40, 252);
             this.colorSlider.TabIndex = 1;
             this.colorSlider.ColorChanged += new MechanikaDesign.WinForms.UI.ColorPicker.ColorSliderVertical.ColorChangedEventHandler(this.colorSlider_ColorChanged);
             // 
@@ -416,20 +390,18 @@ namespace CHColourEditor
             // 
             this.colorBox2D.ColorMode = MechanikaDesign.WinForms.UI.ColorPicker.ColorModes.Hue;
             this.colorBox2D.ColorRGB = System.Drawing.Color.Red;
-            this.colorBox2D.Location = new System.Drawing.Point(12, 65);
-            this.colorBox2D.Margin = new System.Windows.Forms.Padding(6);
+            this.colorBox2D.Location = new System.Drawing.Point(6, 34);
             this.colorBox2D.Name = "colorBox2D";
-            this.colorBox2D.Size = new System.Drawing.Size(490, 485);
+            this.colorBox2D.Size = new System.Drawing.Size(245, 252);
             this.colorBox2D.TabIndex = 0;
             this.colorBox2D.ColorChanged += new MechanikaDesign.WinForms.UI.ColorPicker.ColorBox2D.ColorChangedEventHandler(this.colorBox2D_ColorChanged);
             // 
             // labelHex
             // 
             this.labelHex.AutoSize = true;
-            this.labelHex.Location = new System.Drawing.Point(160, 556);
-            this.labelHex.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.labelHex.Location = new System.Drawing.Point(80, 289);
             this.labelHex.Name = "labelHex";
-            this.labelHex.Size = new System.Drawing.Size(50, 25);
+            this.labelHex.Size = new System.Drawing.Size(26, 13);
             this.labelHex.TabIndex = 30;
             this.labelHex.Text = "Hex";
             // 
@@ -437,19 +409,17 @@ namespace CHColourEditor
             // 
             this.labelCurrentColor.BackColor = System.Drawing.Color.White;
             this.labelCurrentColor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.labelCurrentColor.Location = new System.Drawing.Point(6, 587);
-            this.labelCurrentColor.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.labelCurrentColor.Location = new System.Drawing.Point(3, 305);
             this.labelCurrentColor.Name = "labelCurrentColor";
-            this.labelCurrentColor.Size = new System.Drawing.Size(134, 37);
+            this.labelCurrentColor.Size = new System.Drawing.Size(68, 20);
             this.labelCurrentColor.TabIndex = 29;
             // 
             // labelCurrent
             // 
             this.labelCurrent.AutoSize = true;
-            this.labelCurrent.Location = new System.Drawing.Point(6, 556);
-            this.labelCurrent.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.labelCurrent.Location = new System.Drawing.Point(3, 289);
             this.labelCurrent.Name = "labelCurrent";
-            this.labelCurrent.Size = new System.Drawing.Size(83, 25);
+            this.labelCurrent.Size = new System.Drawing.Size(41, 13);
             this.labelCurrent.TabIndex = 28;
             this.labelCurrent.Text = "Current";
             // 
@@ -461,11 +431,9 @@ namespace CHColourEditor
             // 
             this.texturePreviewContainer.Controls.Add(this.texturePreviewImg);
             this.texturePreviewContainer.Enabled = false;
-            this.texturePreviewContainer.Location = new System.Drawing.Point(1440, 79);
-            this.texturePreviewContainer.Margin = new System.Windows.Forms.Padding(6);
+            this.texturePreviewContainer.Location = new System.Drawing.Point(720, 41);
             this.texturePreviewContainer.Name = "texturePreviewContainer";
-            this.texturePreviewContainer.Padding = new System.Windows.Forms.Padding(6);
-            this.texturePreviewContainer.Size = new System.Drawing.Size(840, 696);
+            this.texturePreviewContainer.Size = new System.Drawing.Size(420, 362);
             this.texturePreviewContainer.TabIndex = 9;
             this.texturePreviewContainer.TabStop = false;
             this.texturePreviewContainer.Text = "Texture Preview";
@@ -473,106 +441,104 @@ namespace CHColourEditor
             // 
             // texturePreviewImg
             // 
-            this.texturePreviewImg.Location = new System.Drawing.Point(12, 37);
-            this.texturePreviewImg.Margin = new System.Windows.Forms.Padding(6);
+            this.texturePreviewImg.Location = new System.Drawing.Point(6, 19);
             this.texturePreviewImg.Name = "texturePreviewImg";
-            this.texturePreviewImg.Size = new System.Drawing.Size(816, 648);
+            this.texturePreviewImg.Size = new System.Drawing.Size(408, 337);
             this.texturePreviewImg.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this.texturePreviewImg.TabIndex = 0;
             this.texturePreviewImg.TabStop = false;
             // 
             // menuStrip1
             // 
-            this.menuStrip1.GripMargin = new System.Windows.Forms.Padding(2, 2, 0, 2);
             this.menuStrip1.ImageScalingSize = new System.Drawing.Size(32, 32);
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItem1,
-            this.toolStripMenuItem6});
+            this.toolStripMenu_FileTab,
+            this.toolStripMenu_HelpTab});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(2304, 42);
+            this.menuStrip1.Padding = new System.Windows.Forms.Padding(3, 1, 0, 1);
+            this.menuStrip1.Size = new System.Drawing.Size(1152, 24);
             this.menuStrip1.TabIndex = 11;
             this.menuStrip1.Text = "menuStrip1";
             // 
-            // toolStripMenuItem1
+            // toolStripMenu_FileTab
             // 
-            this.toolStripMenuItem1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItem2,
-            this.toolStripMenuItem3,
-            this.toolStripMenuItem4,
-            this.toolStripMenuItem5});
-            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(72, 38);
-            this.toolStripMenuItem1.Text = "File";
+            this.toolStripMenu_FileTab.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenu_New,
+            this.toolStripMenu_Open,
+            this.toolStripMenu_Save,
+            this.toolStripMenu_SaveAs});
+            this.toolStripMenu_FileTab.Name = "toolStripMenu_FileTab";
+            this.toolStripMenu_FileTab.Size = new System.Drawing.Size(37, 22);
+            this.toolStripMenu_FileTab.Text = "File";
             // 
-            // toolStripMenuItem2
+            // toolStripMenu_New
             // 
-            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(359, 44);
-            this.toolStripMenuItem2.Text = "New";
+            this.toolStripMenu_New.Name = "toolStripMenu_New";
+            this.toolStripMenu_New.Size = new System.Drawing.Size(114, 22);
+            this.toolStripMenu_New.Text = "New";
             // 
-            // toolStripMenuItem3
+            // toolStripMenu_Open
             // 
-            this.toolStripMenuItem3.Name = "toolStripMenuItem3";
-            this.toolStripMenuItem3.Size = new System.Drawing.Size(359, 44);
-            this.toolStripMenuItem3.Text = "Open";
-            this.toolStripMenuItem3.Click += new System.EventHandler(this.toolStripOpenButton_Click);
+            this.toolStripMenu_Open.Name = "toolStripMenu_Open";
+            this.toolStripMenu_Open.Size = new System.Drawing.Size(114, 22);
+            this.toolStripMenu_Open.Text = "Open";
+            this.toolStripMenu_Open.Click += new System.EventHandler(this.toolStripOpenButton_Click);
             // 
-            // toolStripMenuItem4
+            // toolStripMenu_Save
             // 
-            this.toolStripMenuItem4.Name = "toolStripMenuItem4";
-            this.toolStripMenuItem4.Size = new System.Drawing.Size(359, 44);
-            this.toolStripMenuItem4.Text = "Save";
-            this.toolStripMenuItem4.Click += new System.EventHandler(this.toolStripSaveButton_Click);
+            this.toolStripMenu_Save.Name = "toolStripMenu_Save";
+            this.toolStripMenu_Save.Size = new System.Drawing.Size(114, 22);
+            this.toolStripMenu_Save.Text = "Save";
+            this.toolStripMenu_Save.Click += new System.EventHandler(this.toolStripSaveButton_Click);
             // 
-            // toolStripMenuItem5
+            // toolStripMenu_SaveAs
             // 
-            this.toolStripMenuItem5.Name = "toolStripMenuItem5";
-            this.toolStripMenuItem5.Size = new System.Drawing.Size(359, 44);
-            this.toolStripMenuItem5.Text = "Save As";
-            this.toolStripMenuItem5.Click += new System.EventHandler(this.toolStripSaveAsButton_Click);
+            this.toolStripMenu_SaveAs.Name = "toolStripMenu_SaveAs";
+            this.toolStripMenu_SaveAs.Size = new System.Drawing.Size(114, 22);
+            this.toolStripMenu_SaveAs.Text = "Save As";
+            this.toolStripMenu_SaveAs.Click += new System.EventHandler(this.toolStripSaveAsButton_Click);
             // 
-            // toolStripMenuItem6
+            // toolStripMenu_HelpTab
             // 
-            this.toolStripMenuItem6.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItem7,
-            this.toolStripMenuItem8,
-            this.toolStripMenuItem9});
-            this.toolStripMenuItem6.Name = "toolStripMenuItem6";
-            this.toolStripMenuItem6.Size = new System.Drawing.Size(85, 38);
-            this.toolStripMenuItem6.Text = "Help";
+            this.toolStripMenu_HelpTab.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenu_Changelog,
+            this.toolStripMenu_CheckForUpdates,
+            this.toolStripMenu_About});
+            this.toolStripMenu_HelpTab.Name = "toolStripMenu_HelpTab";
+            this.toolStripMenu_HelpTab.Size = new System.Drawing.Size(44, 22);
+            this.toolStripMenu_HelpTab.Text = "Help";
             // 
-            // toolStripMenuItem7
+            // toolStripMenu_Changelog
             // 
-            this.toolStripMenuItem7.Name = "toolStripMenuItem7";
-            this.toolStripMenuItem7.Size = new System.Drawing.Size(359, 44);
-            this.toolStripMenuItem7.Text = "Changelog";
+            this.toolStripMenu_Changelog.Name = "toolStripMenu_Changelog";
+            this.toolStripMenu_Changelog.Size = new System.Drawing.Size(180, 22);
+            this.toolStripMenu_Changelog.Text = "Changelog";
             // 
-            // toolStripMenuItem8
+            // toolStripMenu_CheckForUpdates
             // 
-            this.toolStripMenuItem8.Name = "toolStripMenuItem8";
-            this.toolStripMenuItem8.Size = new System.Drawing.Size(359, 44);
-            this.toolStripMenuItem8.Text = "Check for Updates";
-            this.toolStripMenuItem8.Click += new System.EventHandler(this.toolStripCheckForUpdates_Click);
+            this.toolStripMenu_CheckForUpdates.Name = "toolStripMenu_CheckForUpdates";
+            this.toolStripMenu_CheckForUpdates.Size = new System.Drawing.Size(180, 22);
+            this.toolStripMenu_CheckForUpdates.Text = "Check for Updates";
+            this.toolStripMenu_CheckForUpdates.Click += new System.EventHandler(this.toolStripCheckForUpdates_Click);
             // 
-            // toolStripMenuItem9
+            // toolStripMenu_About
             // 
-            this.toolStripMenuItem9.Name = "toolStripMenuItem9";
-            this.toolStripMenuItem9.Size = new System.Drawing.Size(359, 44);
-            this.toolStripMenuItem9.Text = "About";
+            this.toolStripMenu_About.Name = "toolStripMenu_About";
+            this.toolStripMenu_About.Size = new System.Drawing.Size(180, 22);
+            this.toolStripMenu_About.Text = "About";
             // 
             // ColorEditor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.ClientSize = new System.Drawing.Size(2304, 848);
+            this.ClientSize = new System.Drawing.Size(1152, 441);
             this.Controls.Add(this.texturePreviewContainer);
             this.Controls.Add(this.editorContainer);
             this.Controls.Add(this.menuStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
-            this.Margin = new System.Windows.Forms.Padding(6);
             this.MaximizeBox = false;
             this.Name = "ColorEditor";
             this.Text = "Clone Hero Color Editor";
@@ -635,15 +601,15 @@ namespace CHColourEditor
         private System.Windows.Forms.GroupBox texturePreviewContainer;
         private System.Windows.Forms.PictureBox texturePreviewImg;
         private System.Windows.Forms.MenuStrip menuStrip1;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem1;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem2;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem3;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem4;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem5;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem6;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem7;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem8;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem9;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenu_FileTab;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenu_New;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenu_Open;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenu_Save;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenu_SaveAs;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenu_HelpTab;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenu_Changelog;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenu_CheckForUpdates;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenu_About;
     }
 }
 

--- a/CHColourEditor/ColorEditor.cs
+++ b/CHColourEditor/ColorEditor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -73,6 +73,11 @@ namespace CHColourEditor
             this.Text = TITLE_STRING;
 
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(ColorEditor_OnFormClosing);
+
+#if DEBUG
+            // Don't allow checking for updates on debug builds
+            toolStripMenu_CheckForUpdates.Enabled = false;
+#endif
 
 #if !DEBUG
             // Automatically check for updates
@@ -351,12 +356,8 @@ namespace CHColourEditor
             }
         }
 
-        private void toolStripCheckForUpdates_Click(object sender, EventArgs e)
+        private async void toolStripCheckForUpdates_Click(object sender, EventArgs e)
         {
-#if DEBUG
-            MessageBox.Show("Cannot check for updates on development builds.", "CH Color Editor Update Checker");
-            return;
-#else
             string newVersionText = await IsOutOfDate(true);
 
             if(newVersionText != string.Empty)
@@ -369,7 +370,6 @@ namespace CHColourEditor
             {
                 MessageBox.Show("The program is up to date!", "CH Color Editor Update Checker");
             }
-#endif
         }
 
         #endregion


### PR DESCRIPTION
Fixes #1

In summary:
- .cfg file parsing can now parse files regardless of if they use `.` or `,` as a decimal separator
  - This parsing can switch on-the-fly if suddenly the decimal point in the file changes between lines (hopefully never an actual case, but this is probably the easiest way to implement it properly)

-  Toolstrip menu items now have proper member names
- Check for Updates button gets disabled entirely when in debug mode, rather than showing a message if in debug mode
  - This eliminates a compiler warning for async functions that don't have an await operator in their function body (namely, the `#if DEBUG` section didn't have one), and just makes a bit more sense imo
-  `toolStripCheckForUpdates_Click` is now once again async, don't know why that was removed

- .gitignore now ignores the `.vscode` folder for Visual Studio Code users

- For whatever reason, the `using System;` lines in both ColorEditor.cs and GameColors.cs got changed in some way? Not sure what's going on there, didn't touch either of those